### PR TITLE
Adding helper(hack-y) scripts to compress and de-compress our db file

### DIFF
--- a/compress_db
+++ b/compress_db
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ echo .dump | sqlite3 $1 | bzip2 -c >wikiwoods.dump.bz2

--- a/uncompress_db
+++ b/uncompress_db
@@ -17,7 +17,7 @@ if ch == 'y':
     open(dump, 'wb').write(data)
     f = open(dump, 'r+')
     linenums = 9
-    s = [y for x, y in enumerate(f) if x not in [line-1 for line in range(linenums)]]
+    s = [y for x, y in enumerate(f) if x not in [line-1 for line in range(3,8)]]
     f.seek(0)
     f.write(''.join(s))
     f.truncate(f.tell())

--- a/uncompress_db
+++ b/uncompress_db
@@ -16,8 +16,7 @@ if ch == 'y':
     dump = dumpfile[:-4]
     open(dump, 'wb').write(data)
     f = open(dump, 'r+')
-    linenums = 9
-    s = [y for x, y in enumerate(f) if x not in [line-1 for line in range(3,8)]]
+    s = [y for x, y in enumerate(f) if x not in [line-1 for line in range(3,9)]]
     f.seek(0)
     f.write(''.join(s))
     f.truncate(f.tell())

--- a/uncompress_db
+++ b/uncompress_db
@@ -34,6 +34,7 @@ if ch == 'y':
         for line in f:
             cursor.executescript(line)
 
+    con.close()
     os.remove('wikiwoods.dump')
     print "wikiwoods.db has been populated!"
 

--- a/uncompress_db
+++ b/uncompress_db
@@ -3,7 +3,7 @@ import sqlite3, sys, os, bz2
 dumpfile = sys.argv[1] if len(sys.argv) > 1 else 'wikiwoods.dump.bz2'
 
 
-ch = raw_input("This will re-write the existing wikiwoods.dm. Continue?(y/n):").lower()
+ch = raw_input("This will re-write the existing wikiwoods.db. Continue?(y/n):").lower()
 
 if ch == 'y':
     try:
@@ -30,12 +30,10 @@ if ch == 'y':
     except:
         pass
 
-    # print "okay"
     with open(dump, 'r') as f:
         for line in f:
-            print line
             cursor.executescript(line)
 
-    # os.remove('wikiwoods.dump')
+    os.remove('wikiwoods.dump')
     print "wikiwoods.db has been populated!"
 

--- a/uncompress_db
+++ b/uncompress_db
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+import sqlite3, sys, os, bz2
+dumpfile = sys.argv[1] if len(sys.argv) > 1 else 'wikiwoods.dump.bz2'
+
+
+ch = raw_input("This will re-write the existing wikiwoods.dm. Continue?(y/n):").lower()
+
+if ch == 'y':
+    try:
+        os.remove('wikiwoods.db')
+        os.remove('wikiwoods.dump')
+    except:
+        pass
+    zipfile = bz2.BZ2File(dumpfile)
+    data = zipfile.read()
+    dump = dumpfile[:-4]
+    open(dump, 'wb').write(data)
+    f = open(dump, 'r+')
+    linenums = 9
+    s = [y for x, y in enumerate(f) if x not in [line-1 for line in range(linenums)]]
+    f.seek(0)
+    f.write(''.join(s))
+    f.truncate(f.tell())
+    f.close()
+
+    con = sqlite3.connect('wikiwoods.db')
+    cursor = con.cursor()
+    try:
+        cursor.executescript('CREATE TABLE wiki_woods (id INTEGER NOT NULL,word TEXT(65),vector TEXT,PRIMARY KEY (id));')
+    except:
+        pass
+
+    # print "okay"
+    with open(dump, 'r') as f:
+        for line in f:
+            print line
+            cursor.executescript(line)
+
+    # os.remove('wikiwoods.dump')
+    print "wikiwoods.db has been populated!"
+


### PR DESCRIPTION
Okay, Now this is a PR I myself am not sure about. 
I have added 2 scripts (mostly hacks) to the repo that will help compressing and uncompressing of wikiwoods easier. Since @minimalparts has a 200MB wikiwoods, I thought this could be of some help.
Usage is pretty straight forward:
To compress:
`./compress_db wikiwoods.db`
This will create a file `wikiwoods_dump.bz2` which is our compressed SQL dump.

To uncompress:
`./uncompress_db wikiwoods.dump.bz2`

Now comes the bad bit:
The compression method used is bz2 which is relatively the fastest and most efficient. But still I am not sure how effective this will be when it comes to a 200MB file.

So the moral of the story is, @minimalparts , if you want to upload the wikiwoods.db as a smaller sizes and sqlite understand-able format you can make use of compress_db. 
To load back the compressed data you can use uncompress_db.

Not proud of this thing. But pushing in a quick hack. Will see if I can do a better job with it or wait for our solution architect( @stultus ) to suggest a better idea. ;)

P.S.: In some cases it looked like the zipped database dump had a mind of it's own. A couple of more hands trying it would be great.
