### PR TITLE
HTML Parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ target/
 
 #don't track app.db - app's sql database
 app.db
+history.db

--- a/create_history_db.py
+++ b/create_history_db.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sqlite3
+import sys
+from os.path import exists
+from urlparse import urlparse
+
+
+def create_history_db(input_db):
+
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+    home_directory = os.path.expanduser('~')
+    os.walk(home_directory)
+    pearsignore = str(home_directory) + '/.pearsignore'
+    f = open(pearsignore, 'r')
+
+    firefox_history_db = input_db
+    if firefox_history_db is None:
+        print 'Cannot find Firefox history database...\n\nExiting...'
+        sys.exit(2)
+
+    # Connect to the firefox history database
+    firefox_con = sqlite3.connect(firefox_history_db)
+
+    # Create the history.db file if it does not exist
+    if not exists('history.db'):
+        new_db = os.open('history.db', flags)
+        os.close(new_db)
+
+    history_con = sqlite3.connect('history.db')
+
+    with firefox_con:
+        firefox_con.row_factory = sqlite3.Row
+        cur = firefox_con.cursor()
+        cur.execute("SELECT * FROM moz_places")
+        rows = cur.fetchall()
+
+        history_cur = history_con.cursor()
+        history_cur.execute("DROP TABLE IF EXISTS History")
+        history_cur.execute("CREATE TABLE History(Id INTEGER PRIMARY KEY, URL TEXT, TITLE TEXT, BODY TEXT)")
+
+        # Get a list of the values from the .pearsignore file in the home directory
+        exclude_list = f.readline().split(',')
+        print exclude_list
+
+        for row in rows:
+            exclude_flag = False
+            url = row['url']
+            # Check to make sure input is a valid url
+            u = urlparse(url)
+            if u.scheme == 'https' or 'http':
+                # Check the exclude list to see if contained in the url
+                for excludes in exclude_list:
+                    if excludes in u.netloc:
+                        exclude_flag = True
+                        print url + ' OMITTED FROM DATABASE'
+                        continue
+                # Commit valid url
+                if exclude_flag is False:
+                    history_cur.execute("INSERT INTO History(URL) VALUES (?)", (url, ))
+                    history_con.commit()
+
+    history_con.close()
+    firefox_con.close()
+
+
+
+
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
+BeautifulSoup==3.2.1
 nltk==3.0.3
 numpy==1.9.2
+requests==2.9.0
 textblob==0.9.1
 web.py==0.37
 wheel==0.24.0

--- a/retrieve_pages.py
+++ b/retrieve_pages.py
@@ -45,6 +45,7 @@ def retrieve_pages():
     for row in rows:
         id = row["Id"]
         url = str(row['URL'])
+        # url = str('http://www.ubuntu.com')
 
         if url.endswith(('.gz', '.zip', '.exe', '.pdf', '.jpeg', '.jpg', '.7z', '.iso', '.img', '.png', '.svg',
                          'mp4', '.mp3', 'ogg', '.avi', '.wma', '.wmv', '.gif', '.rpm', '.deb', '.mkv', '.rar',
@@ -72,11 +73,12 @@ def retrieve_pages():
 
                     if title is None:
                         title = u'Untitled'
-                    for x in bs_obj.find_all(['script', 'style']):
+                    for x in bs_obj.find_all(['script', 'style', 'meta', '<!--', ]):
                         x.extract()
                     body = bs_obj.get_text()
                     title_str = title
                     body_str = body.strip()
+                    print body_str
                     cur.execute("UPDATE History SET title=?, body=? WHERE ID=?", (title_str, body_str, id), )
                     con.commit()
                     print str(r.status_code) + ' - ' + title + ' - Committed.'

--- a/retrieve_pages.py
+++ b/retrieve_pages.py
@@ -1,0 +1,110 @@
+
+# -*- coding: utf-8 -*-
+from bs4 import BeautifulSoup
+import os
+import platform
+import re
+import requests
+import sqlite3
+import sys
+from urllib2 import HTTPError
+from create_history_db import create_history_db
+
+HISTORY_DB = ''
+
+print platform.system(), platform.release()
+home_directory = os.path.expanduser('~')
+print home_directory
+
+
+def get_firefox_history_db(in_dir):
+    """Given a home directory it will search it for the places.sqlite file
+    in Mozilla Firefox and return the path. This should work on Windows/Linux"""
+
+    firefox_directory = in_dir + "/.mozilla/firefox"
+    print firefox_directory
+    for files in os.walk(firefox_directory):
+        # Build the filename
+        if re.search('places.sqlite', str(os.path.join(files))):
+            history_db = str(os.path.realpath(files[0])+'/places.sqlite')
+            print history_db
+            return history_db
+
+    return None
+
+print HISTORY_DB
+
+
+def retrieve_pages():
+    con = sqlite3.connect('history.db')
+    con.row_factory = sqlite3.Row
+    cur = con.cursor()
+    cur.execute("SELECT * FROM History;")
+    rows = cur.fetchall()
+
+    for row in rows:
+        id = row["Id"]
+        url = str(row['URL'])
+
+        if url.endswith(('.gz', '.zip', '.exe', '.pdf', '.jpeg', '.jpg', '.7z', '.iso', '.img', '.png', '.svg',
+                         'mp4', '.mp3', 'ogg', '.avi', '.wma', '.wmv', '.gif', '.rpm', '.deb', '.mkv', '.rar',
+                         '.m4a', '.tgz', '.tar', '.webm')):
+            print url + ' is a binary - omitted from database'
+            continue
+
+        try:
+            r = requests.get(url, allow_redirects=False)
+            r.encoding = 'utf-8'
+            print str(r.status_code) + ' - ' + str(r.url)
+            if r.status_code is not 200:
+                print str(r.url) + ' has a status code of: ' + str(r.status_code) + ' omitted from database.'
+                continue
+        except:
+            e = sys.exc_info()[0]
+            print "Error - %s" % e
+            continue
+
+        bs_obj = BeautifulSoup(r.text)
+        if hasattr(bs_obj.title, 'string') & (r.status_code == requests.codes.ok):
+            try:
+                title = unicode(bs_obj.title.string)
+                if url.startswith('http'):
+
+                    if title is None:
+                        title = u'Untitled'
+                    for x in bs_obj.find_all(['script', 'style']):
+                        x.extract()
+                    body = bs_obj.get_text()
+                    title_str = title
+                    body_str = body.strip()
+                    cur.execute("UPDATE History SET title=?, body=? WHERE ID=?", (title_str, body_str, id), )
+                    con.commit()
+                    print str(r.status_code) + ' - ' + title + ' - Committed.'
+
+                if title is None:
+                    title = u'Untitled'
+            except HTTPError as e:
+                title = u'Untitled'
+            except None:
+                title = u'Untitled'
+                continue
+        else:
+            continue
+
+    con.close()
+
+
+if __name__ == '__main__':
+
+    HISTORY_DB = get_firefox_history_db(home_directory)
+    if HISTORY_DB is None:
+        print 'Error - Cannot find the Firefox history database.\n\nExiting...'
+        sys.exit(1)
+
+    # If the firefox history db exists we then want to create our own version from it, minus the domains specified in
+    # the user's ~/.pearsignore.
+    #
+    if not HISTORY_DB:
+        create_history_db(HISTORY_DB)
+
+    retrieve_pages()


### PR DESCRIPTION
**Overview**

Here are the files that will create a database of pages that excludes domains from a comma-delineated user supplied list called .pearsignore, that is located in the home directory.

The reason the .pearsignore file is in the home directory is that we wanted users to be able to keep their exclude list private. This way it will never be committed into the repository. Thoughts around this strategy are appreciated.

I would suggest we at least document a generic .pearsignore, because it would save people a lot of time configuring their own.  This programme can take some time to run dependant upon the size of the original Firefox browsing history.  At this time it prints to standard out to enable you to see what urls are being committed and omitted.

[.pearsignore.txt](https://github.com/minimalparts/PeARS/files/66099/default.pearsignore.txt)

Run retrieve_pages.py to execute.

See commit message for details.

This is a very rough draft but I have run out of urls to test it with. 

**Assumptions**

The user is running a linux distribution and is using the latest Firefox as a browser.
